### PR TITLE
Superblock Config Partitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ ifeq ($(shell uname -s), Darwin)
 	INCLUDE_DIR = $(OSXFUSE_ROOT)/include/osxfuse/fuse
 	LIBRARY_DIR = $(OSXFUSE_ROOT)/lib
 
-	CXXFLAGS += -I$(INCLUDE_DIR) -L$(LIBRARY_DIR)
+	CXXFLAGS += -I$(INCLUDE_DIR)
 	CXXFLAGS += -D_DARWIN_USE_64_BIT_INODE
-	LDFLAGS   = -losxfuse
+	LDFLAGS   = -losxfuse -L$(LIBRARY_DIR)
 else
 	LDFLAGS   = -lfuse
 endif

--- a/src/lib/INodeManager.h
+++ b/src/lib/INodeManager.h
@@ -7,7 +7,7 @@ public:
   virtual ~INodeManager() {}
   virtual INode::ID reserve() = 0;
   virtual void release(INode::ID id) = 0;
-  virtual void get(INode::ID inode_num, INode& user_inode) = 0;
-  virtual void set(INode::ID inode_num, INode& user_inode) = 0;
+  virtual void get(INode::ID id, INode& dst) = 0;
+  virtual void set(INode::ID id, const INode& src) = 0;
   virtual INode::ID getRoot() = 0;
 };

--- a/src/lib/Superblock.h
+++ b/src/lib/Superblock.h
@@ -1,10 +1,22 @@
 #pragma once
 
-#include <cstdint>
+#include "Block.h"
 
 struct Superblock {
-  uint64_t block_count;
-  uint64_t inode_count;
-  uint64_t free_list_block;
-  uint64_t free_list_index;
+  union {
+    uint64_t config[16];
+    struct {
+      uint64_t  block_size;
+      uint64_t  block_count;
+
+      Block::ID inode_block_start;
+      uint64_t  inode_block_count;
+
+      Block::ID data_block_start;
+      uint64_t  data_block_count;
+    };
+  };
+
+  uint64_t inode_config[8];
+  uint64_t data_config[8];
 };

--- a/src/lib/blocks/StackBasedBlockManager.cpp
+++ b/src/lib/blocks/StackBasedBlockManager.cpp
@@ -1,12 +1,44 @@
 #include "StackBasedBlockManager.h"
 
-StackBasedBlockManager::StackBasedBlockManager(Block::ID top_block_num, uint64_t index, Storage& storage) {
-  this->top_block_num = top_block_num;
-  this->index = index;
-  this->disk = &storage;
+// Anonymous namespace for file-local types:
+namespace {
+  struct DatablockNode {
+    static const int NREFS = (Block::BLOCK_SIZE / sizeof(Block::ID) - 2);
+
+    Block::ID prev_block = 0;
+    Block::ID next_block = 0;
+    Block::ID free_blocks[NREFS];
+  };
+
+  struct Config {
+    uint64_t  magic; // Magic number to identify this block manager (ignored for now)
+    Block::ID block; // Block ID of the top block on the stack
+    uint64_t  index; // Index of the first free ref in that block
+  };
+}
+
+StackBasedBlockManager::StackBasedBlockManager(Storage& storage): disk(&storage) {
+  Block block;
+  Superblock* superblock = (Superblock*) &block;
+  Config* config = (Config*) superblock->data_config;
+  this->disk->get(0, block);
+
+  this->top_block_num = config->block;
+  this->index         = config->index;
 }
 
 StackBasedBlockManager::~StackBasedBlockManager() {}
+
+void StackBasedBlockManager::update_superblock() {
+  Block block;
+  Superblock* superblock = (Superblock*) &block;
+  Config* config = (Config*) superblock->data_config;
+
+  this->disk->get(0, block);
+  config->block = this->top_block_num;
+  config->index = this->index;
+  this->disk->set(0, block);
+}
 
 void StackBasedBlockManager::release(Block::ID free_block_num) {
   // Read top block in freelist from disk
@@ -17,8 +49,10 @@ void StackBasedBlockManager::release(Block::ID free_block_num) {
   // If insertion causes index to overflow the block,
   // move to previous block in free list.
   if (this->index + 1 >= DatablockNode::NREFS) {
-    if (!node->prev_block)
+    if (!node->prev_block) {
       throw std::out_of_range("Can't insert block at top of data block free list!");
+    }
+
     this->top_block_num = node->prev_block;
     this->disk->get(this->top_block_num, block);
     index = 0;
@@ -26,16 +60,10 @@ void StackBasedBlockManager::release(Block::ID free_block_num) {
     index++;
   }
 
-  // Update the top block's free list
+  // Update the free list
   node->free_blocks[this->index] = free_block_num;
   this->disk->set(this->top_block_num, block);
-
-  // Update superblock
-  Superblock *super_block = (Superblock*) &block;
-  this->disk->get(0, block);
-  super_block->free_list_block = top_block_num;
-  super_block->free_list_index = index;
-  this->disk->set(0, block);
+  this->update_superblock();
 }
 
 Block::ID StackBasedBlockManager::reserve() {
@@ -47,7 +75,7 @@ Block::ID StackBasedBlockManager::reserve() {
 
   // Check if free list is almost empty and refuse allocation of last block
   if (!node->next_block && !this->index) {
-      throw std::out_of_range("Can't get any more free blocks - free list is empty!");
+    throw std::out_of_range("Can't get any more free blocks - free list is empty!");
   }
 
   // Get next free block
@@ -59,11 +87,6 @@ Block::ID StackBasedBlockManager::reserve() {
     this->index--;
   }
 
-  // Update superblock
-  Superblock *super_block = (Superblock *) &block;
-  this->disk->get(0, block);
-  super_block->free_list_block = top_block_num;
-  super_block->free_list_index = index;
-  this->disk->set(0, block);
+  this->update_superblock();
   return free_block_num;
 }

--- a/src/lib/blocks/StackBasedBlockManager.h
+++ b/src/lib/blocks/StackBasedBlockManager.h
@@ -6,20 +6,16 @@
 #include "../Storage.h"
 #include "../Superblock.h"
 
-struct DatablockNode {
-  static const int NREFS = (Block::BLOCK_SIZE / sizeof(Block::ID) - 2);
-
-  Block::ID prev_block = 0;
-  Block::ID next_block = 0;
-  Block::ID free_blocks[NREFS];
-};
-
 class StackBasedBlockManager: public BlockManager {
 public:
-  StackBasedBlockManager(Block::ID top_block_num, uint64_t index, Storage& disk);
+  StackBasedBlockManager(Storage& disk);
   ~StackBasedBlockManager();
+
   virtual void release(Block::ID block_num);
   virtual Block::ID reserve();
+
+  void update_superblock();
+
 private:
   Block::ID top_block_num;
   uint64_t index;

--- a/src/lib/inodes/LinearINodeManager.cpp
+++ b/src/lib/inodes/LinearINodeManager.cpp
@@ -1,15 +1,23 @@
 #include "LinearINodeManager.h"
+#include "../Superblock.h"
 
-LinearINodeManager::LinearINodeManager(uint64_t num_inodes, Storage& storage)
-{
-	this->num_inodes = num_inodes;
-	this->disk = &storage;
+#include <cstring>
+#include <stdexcept>
+
+LinearINodeManager::LinearINodeManager(Storage& storage): disk(&storage) {
+	Block block;
+  Superblock* superblock = (Superblock*) &block;
+  this->disk->get(0, block);
+
+  uint64_t num_inodes_per_block = Block::BLOCK_SIZE / INode::INODE_SIZE;
+  this->num_inodes = num_inodes_per_block * superblock->inode_block_count;
 }
 
 LinearINodeManager::~LinearINodeManager() {}
 
 // Get an inode from the freelist and return it
-INode::ID LinearINodeManager::reserve(Block &block) {
+INode::ID LinearINodeManager::reserve() {
+  Block block;
 	uint64_t num_inodes_per_block = Block::BLOCK_SIZE / INode::INODE_SIZE;
 	for (uint64_t block_index = 0; block_index < this->num_inodes / num_inodes_per_block; block_index++) {
 

--- a/src/lib/inodes/LinearINodeManager.h
+++ b/src/lib/inodes/LinearINodeManager.h
@@ -1,20 +1,18 @@
 #pragma once
 
-#include <stdexcept>
-#include <cstdint>
-#include <string.h>
 #include "../INodeManager.h"
 #include "../Storage.h"
 #include "../Block.h"
 
 class LinearINodeManager: public INodeManager {
 public:
-	LinearINodeManager(uint64_t num_inodes, Storage& storage);
+	LinearINodeManager(Storage& storage);
 	~LinearINodeManager();
-	INode::ID reserve(Block &block);
+
+	INode::ID reserve();
 	void release(INode::ID id);
-	void get(INode::ID inode_num, INode& user_inode);
-	void set(INode::ID inode_num, const INode& user_inode);
+	void get(INode::ID id, INode& dst);
+	void set(INode::ID id, const INode& src);
 	INode::ID getRoot();
 
 private:


### PR DESCRIPTION
This adds generic partitions to the superblock that *Manager implementations can use to store implementation-dependent data.  See StackBasedBlockManager.cpp for an example using a Config overlay struct.

Additionally, *Manager constructors now simply take a single Storage argument.  They're in charge of loading the superblock via that Storage object, then reading whatever configuration they need.