### PR TITLE
E2BIG

### DIFF
--- a/src/lib/FSExceptions.h
+++ b/src/lib/FSExceptions.h
@@ -28,6 +28,11 @@ struct DirectoryNotEmpty: public FSException {
   DirectoryNotEmpty(const std::string& path): FSException(std::errc::directory_not_empty, "Directory not empty: " + path) {}
 };
 
+struct FileTooBig: public FSException {
+  FileTooBig(): FSException(std::errc::file_too_large, "File too big!") {}
+  FileTooBig(const std::string& path): FSException(std::errc::file_too_large, "File too big: " + path) {}
+};
+
 struct IOError: public FSException {
   IOError(): FSException(std::errc::io_error, "IO error!") {}
   IOError(const std::string& message): FSException(std::errc::io_error, message) {}

--- a/src/lib/Filesystem.cpp
+++ b/src/lib/Filesystem.cpp
@@ -20,6 +20,13 @@ Filesystem::Filesystem(BlockManager& block_manager, INodeManager& inode_manager,
   this->block_manager = &block_manager;
   this->inode_manager = &inode_manager;
   this->disk = &storage;
+
+  uint64_t ipb   = Block::SIZE / sizeof(Block::ID);
+  max_file_size  = INode::DIRECT_POINTERS;
+  max_file_size += INode::SINGLE_INDIRECT_POINTERS * ipb;
+  max_file_size += INode::DOUBLE_INDIRECT_POINTERS * ipb * ipb;
+  max_file_size += INode::TRIPLE_INDIRECT_POINTERS * ipb * ipb * ipb;
+  max_file_size *= Block::SIZE;
 }
 
 Filesystem::~Filesystem() {
@@ -128,6 +135,9 @@ void Filesystem::save(INode::ID id, const INode& inode) {
  * - TODO: Incorrect ownership/permissions
  */
 int Filesystem::write(INode::ID file_inode_num, const char *buf, size_t size, size_t offset) {
+  if(offset > max_file_size || size > max_file_size - offset) {
+    throw FileTooBig();
+  }
 
   // Read the file's inode and do some sanity checks
   INode file_inode;
@@ -407,9 +417,7 @@ Block::ID Filesystem::allocateNextBlock(INode& file_inode) {
 int Filesystem::read(INode::ID file_inode_num, char *buf, size_t size, size_t offset) {
 
   // Read the file's inode and do some sanity checks
-  INode file_inode;
-  this->inode_manager->get(file_inode_num, file_inode);
-
+  INode file_inode = getINode(file_inode_num);
   if (offset >= file_inode.size) {
     return -1; // Can't begin reading from after file
   }
@@ -504,11 +512,12 @@ Block::ID Filesystem::indirectBlockAt(Block::ID bid, uint64_t offset, uint64_t s
 }
 
 int Filesystem::truncate(INode::ID file_inode_num, size_t length) {
+  if(length > max_file_size) {
+    throw FileTooBig();
+  }
 
   // Read the file's inode and do some sanity checks
-  INode file_inode;
-  this->inode_manager->get(file_inode_num, file_inode);
-
+  INode file_inode = getINode(file_inode_num);
   if (file_inode.size == length) {
     return 0;
   }

--- a/src/lib/Filesystem.h
+++ b/src/lib/Filesystem.h
@@ -10,9 +10,10 @@
 struct statvfs;
 
 class Filesystem {
-  BlockManager *block_manager;
-  INodeManager *inode_manager;
-  Storage *disk;
+  BlockManager* block_manager;
+  INodeManager* inode_manager;
+  uint64_t      max_file_size;
+  Storage*      disk;
 public:
   Filesystem(BlockManager &block_manager, INodeManager& inode_manager, Storage &storage);
   ~Filesystem();


### PR DESCRIPTION
Turns out the existing exceptions were all for corner cases that could only happen if _we_ messed up, so I didn't convert them to FSExceptions.  I did add a max file size calculation to Filesystem, though, and throw the new exception if a write or truncate would go past the max file size.