### PR TITLE
CLI Mark II

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ fsck: bin/fsck
 
 # Pattern for executables:
 bin/%: obj/%.o $(OBJECTS)
-	${CXX} $(CXXFLAGS) $(LDFLAGS) -o $@ $^
+	${CXX} $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Pattern for objects:
 obj/%.o: src/%.cpp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # SIGSEGV
+
+<img src="https://travis-ci.com/chippermist/SIGSEGV.svg?branch=master" />

--- a/src/fuse.cpp
+++ b/src/fuse.cpp
@@ -459,6 +459,7 @@ int main(int argc, char** argv) {
   BlockManager *block_manager = new StackBasedBlockManager(*disk);
   inode_manager = new LinearINodeManager(*disk);
   fs = new Filesystem(*block_manager, *inode_manager, *disk);
+  fs->mkfs(1024);
 
   // Set FUSE function pointers
   fuse_operations ops;

--- a/src/fuse.cpp
+++ b/src/fuse.cpp
@@ -1,4 +1,3 @@
-#include "lib/CommandLine.h"
 #include "lib/Filesystem.h"
 #include "lib/FSExceptions.h"
 
@@ -441,7 +440,7 @@ extern "C" {
 }
 
 int main(int argc, char** argv) {
-  fs = parse(argc, argv, false);
+  fs = new Filesystem(argc, argv, false);
   // TODO: Make sure FS config matches!
 
   fuse_operations ops;
@@ -479,8 +478,7 @@ int main(int argc, char** argv) {
   ops.utime       = &fs_utime;
   ops.write       = &fs_write;
 
-  // Run the FUSE daemon!
-  return fuse_main(argc, argv, &ops, NULL);
+  return fs->mount(&ops);
 }
 
 /*

--- a/src/lib/CommandLine.cpp
+++ b/src/lib/CommandLine.cpp
@@ -20,10 +20,6 @@ static void usage(const char* message = NULL) {
 }
 
 Filesystem::Filesystem(int argc, char** argv, bool mkfs) {
-  for(int i = 0; i < argc; ++i) {
-    std::cout << i << ": " << argv[i] << '\n';
-  }
-
   char*    disk_file   = NULL;
   uint64_t block_size  = 4096;
   uint64_t block_count = 0;

--- a/src/lib/CommandLine.cpp
+++ b/src/lib/CommandLine.cpp
@@ -1,0 +1,111 @@
+#include "Filesystem.h"
+
+#include "blocks/StackBasedBlockManager.h"
+#include "inodes/LinearINodeManager.h"
+#include "storage/MemoryStorage.h"
+#include "storage/FileStorage.h"
+
+#include <iostream>
+#include <getopt.h>
+
+static void usage(const char* message = NULL) {
+  if(message) std::cerr << message << "\n\n";
+  std::cerr << "--block-size  -b <num>  Block size (defaults to 4096).\n";
+  std::cerr << "--block-count -n <num>  Total number of blocks (mkfs only).\n";
+  std::cerr << "--inode-count -i <num>  Minimum number of INodes (mkfs only).\n";
+  std::cerr << "--disk-file   -f <str>  File or device to use for storage.\n";
+  exit(1);;
+}
+
+Filesystem* parse(int argc, char** argv, bool mkfs) {
+  char*    disk_file   = NULL;
+  uint64_t block_size  = 4096;
+  uint64_t block_count = 0;
+  uint64_t inode_count = 0;
+
+  struct option options[] = {
+    {"block-size",  required_argument, 0, 'b'},
+    {"block-count", required_argument, 0, 'n'},
+    {"inode-count", required_argument, 0, 'i'},
+    {"disk-file",   required_argument, 0, 'f'},
+    {0, 0, 0, 0}
+  };
+
+  while(true) {
+    int i = 0;
+    int c = getopt_long(argc, argv, "b:n:i:f:", options, &i);
+    if(c == -1) break;
+
+    switch(c) {
+    case 'b':
+      block_size = atoi(optarg);
+      break;
+    case 'n':
+      block_count = atoi(optarg);
+      break;
+    case 'i':
+      inode_count = atoi(optarg);
+      break;
+    case 'f':
+      disk_file = optarg;
+      break;
+    default:
+      std::cerr << "Unknown argument: " << argv[i] << '\n';
+      exit(1);
+    }
+  }
+
+  // We always need to initialize memory storage.
+  if(disk_file == NULL) mkfs = true;
+
+  if(block_size < 256) {
+    usage("Block size must be at least 256 bytes.");
+  }
+
+  uint64_t n = block_size;
+  while(n > 0) n <<= 1;
+  if(n != 1) {
+    usage("Block size must be a power of two.");
+  }
+
+  if(block_count == 0) {
+    usage("Block count is a required argument.");
+  }
+  else if(!mkfs) {
+    usage("Block count option is only valid for mkfs.");
+  }
+
+  uint64_t inode_blocks = 0;
+  if(inode_count == 0) {
+    inode_blocks = block_count / 10;
+  }
+  else if(mkfs) {
+    uint64_t ipb = block_size / sizeof(INode::ID);
+    inode_blocks = (inode_count + ipb - 1) / ipb;
+  }
+  else {
+    usage("INode count option is only valid for mkfs.");
+  }
+
+  if(inode_blocks >= block_count / 2) {
+    usage("Too many INode blocks.");
+  }
+
+  Storage* disk = NULL;
+  if(disk_file != NULL) {
+    disk = new FileStorage(disk_file, block_count);
+  }
+  else {
+    disk = new MemoryStorage(block_count);
+  }
+
+  INodeManager* inodes     = new LinearINodeManager(*disk);
+  BlockManager* blocks     = new StackBasedBlockManager(*disk);
+  Filesystem*   filesystem = new Filesystem(*blocks, *inodes);
+
+  if(mkfs) {
+    filesystem->mkfs(block_count, inode_blocks);
+  }
+
+  return filesystem;
+}

--- a/src/lib/CommandLine.h
+++ b/src/lib/CommandLine.h
@@ -1,4 +1,0 @@
-#pragma once
-
-class Filesystem;
-Filesystem* parse(int argc, char** argv, bool mkfs);

--- a/src/lib/CommandLine.h
+++ b/src/lib/CommandLine.h
@@ -1,0 +1,4 @@
+#pragma once
+
+class Filesystem;
+Filesystem* parse(int argc, char** argv, bool mkfs);

--- a/src/lib/FSExceptions.h
+++ b/src/lib/FSExceptions.h
@@ -67,7 +67,6 @@ struct NotASymlink: public FSException {
 };
 
 struct NoSuchEntry: public FSException {
-  // TODO: Alternative constructor that takes a path.
   NoSuchEntry(): FSException(std::errc::no_such_file_or_directory, "No such entry!") {}
   NoSuchEntry(const std::string& path): FSException(std::errc::no_such_file_or_directory, "No such entry: " + path) {}
 };

--- a/src/lib/Filesystem.cpp
+++ b/src/lib/Filesystem.cpp
@@ -26,7 +26,26 @@ Filesystem::~Filesystem() {
   // Nothing to do.
 }
 
-void Filesystem::mkfs() {
+void Filesystem::mkfs(uint64_t nblocks) {
+  uint64_t niblocks = nblocks / 10;
+  mkfs(nblocks, niblocks);
+}
+
+void Filesystem::mkfs(uint64_t nblocks, uint64_t niblocks) {
+  Block block;
+  Superblock* superblock = (Superblock*) block.data;
+  block_manager->get(0, block);
+
+  superblock->magic       = 3199905246;
+  superblock->block_size  = Block::SIZE;
+  superblock->block_count = nblocks;
+
+  superblock->inode_block_start = 1;
+  superblock->inode_block_count = niblocks;
+  superblock->data_block_start  = niblocks + 1;
+  superblock->data_block_count  = nblocks - niblocks - 1;
+
+  block_manager->set(0, block);
   inode_manager->mkfs();
   block_manager->mkfs();
 

--- a/src/lib/Filesystem.cpp
+++ b/src/lib/Filesystem.cpp
@@ -79,14 +79,16 @@ int Filesystem::mount(fuse_operations* ops) {
     exit(1);
   }
 
-  char s[] = "-s";
-  char d[] = "-d";
+  char s[] = "-s"; // Use a single thread.
+  char d[] = "-d"; // Print debuging output.
+  char f[] = "-f"; // Run in the foreground.
 
   int argc = 0;
-  char* argv[4] = {0};
+  char* argv[8] = {0};
 
   if(!parallel) argv[argc++] = s;
   if(debug)     argv[argc++] = d;
+  argv[argc++] = f;
   argv[argc++] = mount_point;
 
   return fuse_main(argc, argv, ops, 0);

--- a/src/lib/Filesystem.cpp
+++ b/src/lib/Filesystem.cpp
@@ -73,6 +73,25 @@ void Filesystem::statfs(struct statvfs* info) {
   info->f_namemax = 256;                    // Maximum filename length.
 }
 
+int Filesystem::mount(fuse_operations* ops) {
+  if(mount_point == NULL) {
+    std::cerr << "No mount point given.\n";
+    exit(1);
+  }
+
+  char s[] = "-s";
+  char d[] = "-d";
+
+  int argc = 0;
+  char* argv[4] = {0};
+
+  if(!parallel) argv[argc++] = s;
+  if(debug)     argv[argc++] = d;
+  argv[argc++] = mount_point;
+
+  return fuse_main(argc, argv, ops, 0);
+}
+
 Directory Filesystem::getDirectory(INode::ID id) {
   INode inode;
   inode_manager->get(id, inode);

--- a/src/lib/Filesystem.cpp
+++ b/src/lib/Filesystem.cpp
@@ -16,19 +16,13 @@
   #include <fuse.h>
 #endif
 
-Filesystem::Filesystem(BlockManager& block_manager, INodeManager& inode_manager, Storage& storage) {
+Filesystem::Filesystem(BlockManager& block_manager, INodeManager& inode_manager) {
   this->block_manager = &block_manager;
   this->inode_manager = &inode_manager;
-  this->disk = &storage;
 }
 
 Filesystem::~Filesystem() {
   // Nothing to do.
-}
-
-void Filesystem::mkfs(uint64_t nblocks) {
-  uint64_t niblocks = nblocks / 10;
-  mkfs(nblocks, niblocks);
 }
 
 void Filesystem::mkfs(uint64_t nblocks, uint64_t niblocks) {
@@ -121,6 +115,10 @@ INode::ID Filesystem::getINodeID(const std::string& path) {
   return id;
 }
 
+INode::ID Filesystem::newINodeID() {
+  return inode_manager->reserve();
+}
+
 void Filesystem::save(const Directory& directory) {
   std::vector<char> data = directory.serialize();
   write(directory.id(), &data[0], data.size(), 0);
@@ -163,7 +161,7 @@ int Filesystem::write(INode::ID file_inode_num, const char *buf, size_t size, si
     // Read in block
     Block block;
     Block::ID block_num = blockAt(file_inode, offset);
-    this->disk->get(block_num, block);
+    this->block_manager->get(block_num, block);
 
     /*
       How many bytes to write?
@@ -186,7 +184,7 @@ int Filesystem::write(INode::ID file_inode_num, const char *buf, size_t size, si
 
     // Copy the data and write to disk
     memcpy(block.data + (offset % Block::SIZE), buf, to_write);
-    this->disk->set(block_num, block);
+    this->block_manager->set(block_num, block);
 
     // Update offset, buf pointer, and num bytes left to write
     offset += to_write;
@@ -230,7 +228,7 @@ size_t Filesystem::appendData(INode& file_inode, const char *buf, size_t size, s
   if (offset % Block::SIZE != 0) {
     Block block;
     Block::ID block_num = blockAt(file_inode, offset);
-    this->disk->get(block_num, block);
+    this->block_manager->get(block_num, block);
 
     /*
       How many bytes to write?
@@ -248,7 +246,7 @@ size_t Filesystem::appendData(INode& file_inode, const char *buf, size_t size, s
     } else {
       memcpy(block.data  + (offset % Block::SIZE), buf, to_write);
     }
-    this->disk->set(block_num, block);
+    this->block_manager->set(block_num, block);
 
     // Update offset, buf pointer, and num bytes left to write
     offset += to_write;
@@ -289,7 +287,7 @@ size_t Filesystem::appendData(INode& file_inode, const char *buf, size_t size, s
     } else {
       memcpy(block.data, buf, to_write);
     }
-    this->disk->set(block_num, block);
+    this->block_manager->set(block_num, block);
 
     // Update offset, buf pointer, and num bytes left to write
     offset += to_write;
@@ -332,13 +330,13 @@ Block::ID Filesystem::allocateNextBlock(INode& file_inode) {
     // 2. Load in first level block
     Block direct_ptrs_blk;
     Block::ID *direct_ptrs = (Block::ID *) &direct_ptrs_blk;
-    this->disk->get(file_inode.block_pointers[INode::DIRECT_POINTERS], direct_ptrs_blk);
+    this->block_manager->get(file_inode.block_pointers[INode::DIRECT_POINTERS], direct_ptrs_blk);
 
     // 3. Allocate the direct block
     logical_blk_num -= INode::DIRECT_POINTERS;
     data_block_num = this->block_manager->reserve();
     direct_ptrs[logical_blk_num - 1] = data_block_num;
-    this->disk->set(file_inode.block_pointers[INode::DIRECT_POINTERS], direct_ptrs_blk);
+    this->block_manager->set(file_inode.block_pointers[INode::DIRECT_POINTERS], direct_ptrs_blk);
 
   } else if (logical_blk_num <= INode::DIRECT_POINTERS + scale + (scale * scale)) {
 
@@ -352,24 +350,24 @@ Block::ID Filesystem::allocateNextBlock(INode& file_inode) {
     // 2. Load in first level block
     Block single_indirect_ptrs_blk;
     Block::ID *single_indirect_ptrs = (Block::ID *) &single_indirect_ptrs_blk;
-    this->disk->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 1], single_indirect_ptrs_blk);
+    this->block_manager->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 1], single_indirect_ptrs_blk);
 
     // 3. Check if need block for direct pointers
     Block::ID block_idx_in_level = logical_blk_num - INode::DIRECT_POINTERS - scale - 1;
     if (block_idx_in_level % scale == 0) {
       single_indirect_ptrs[block_idx_in_level / scale] = this->block_manager->reserve();
-      this->disk->set(file_inode.block_pointers[INode::DIRECT_POINTERS + 1], single_indirect_ptrs_blk);
+      this->block_manager->set(file_inode.block_pointers[INode::DIRECT_POINTERS + 1], single_indirect_ptrs_blk);
     }
 
     // 4. Load in second level block
     Block direct_ptrs_blk;
     Block::ID *direct_ptrs = (Block::ID *) &direct_ptrs_blk;
-    this->disk->get(single_indirect_ptrs[block_idx_in_level / scale], direct_ptrs_blk);
+    this->block_manager->get(single_indirect_ptrs[block_idx_in_level / scale], direct_ptrs_blk);
 
     // 5. Allocate the direct block
     data_block_num = this->block_manager->reserve();
     direct_ptrs[block_idx_in_level % scale] = data_block_num;
-    this->disk->set(single_indirect_ptrs[block_idx_in_level / scale], direct_ptrs_blk);
+    this->block_manager->set(single_indirect_ptrs[block_idx_in_level / scale], direct_ptrs_blk);
 
   } else if (logical_blk_num <= INode::DIRECT_POINTERS + scale + (scale * scale) + (scale * scale * scale)) {
     // Triple-indirect
@@ -382,36 +380,36 @@ Block::ID Filesystem::allocateNextBlock(INode& file_inode) {
     // 2. Load in first level block
     Block double_indirect_ptrs_blk;
     Block::ID *double_indirect_ptrs = (Block::ID *) &double_indirect_ptrs_blk;
-    this->disk->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 2], double_indirect_ptrs_blk);
+    this->block_manager->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 2], double_indirect_ptrs_blk);
 
     // 3. Check if need block for single-indirect pointers
     Block::ID block_idx_in_level = logical_blk_num - INode::DIRECT_POINTERS - scale - scale * scale - 1;
     if (block_idx_in_level % (scale * scale) == 0) {
       double_indirect_ptrs[block_idx_in_level / (scale * scale)] = this->block_manager->reserve();
-      this->disk->set(file_inode.block_pointers[INode::DIRECT_POINTERS + 2], double_indirect_ptrs_blk);
+      this->block_manager->set(file_inode.block_pointers[INode::DIRECT_POINTERS + 2], double_indirect_ptrs_blk);
     }
 
     // 4. Load in second level block
     Block single_indirect_ptrs_blk;
     Block::ID *single_indirect_ptrs = (Block::ID *) &single_indirect_ptrs_blk;
-    this->disk->get(double_indirect_ptrs[block_idx_in_level / (scale * scale)], single_indirect_ptrs_blk);
+    this->block_manager->get(double_indirect_ptrs[block_idx_in_level / (scale * scale)], single_indirect_ptrs_blk);
 
     // 5. Check if need block for direct pointers
     Block::ID block_idx_in_level_two = block_idx_in_level % (scale * scale);
     if (block_idx_in_level_two % scale == 0) {
       single_indirect_ptrs[block_idx_in_level_two / scale] = this->block_manager->reserve();
-      this->disk->set(double_indirect_ptrs[block_idx_in_level / (scale * scale)], single_indirect_ptrs_blk);
+      this->block_manager->set(double_indirect_ptrs[block_idx_in_level / (scale * scale)], single_indirect_ptrs_blk);
     }
 
     // 6. Load in third level block
     Block direct_ptrs_blk;
     Block::ID *direct_ptrs = (Block::ID *) &direct_ptrs_blk;
-    this->disk->get(single_indirect_ptrs[block_idx_in_level_two / scale], direct_ptrs_blk);
+    this->block_manager->get(single_indirect_ptrs[block_idx_in_level_two / scale], direct_ptrs_blk);
 
     // 7. Allocate direct block
     data_block_num = this->block_manager->reserve();
     direct_ptrs[block_idx_in_level_two % scale] = data_block_num;
-    this->disk->set(single_indirect_ptrs[block_idx_in_level_two / scale], direct_ptrs_blk);
+    this->block_manager->set(single_indirect_ptrs[block_idx_in_level_two / scale], direct_ptrs_blk);
 
   } else {
     // Can't allocate any more blocks for this file!
@@ -446,7 +444,7 @@ int Filesystem::read(INode::ID file_inode_num, char *buf, size_t size, size_t of
     // Get datablock of current offset
     Block::ID cur_block_id = blockAt(file_inode, offset);
     Block block;
-    this->disk->get(cur_block_id, block);
+    this->block_manager->get(cur_block_id, block);
 
     /*
       How many bytes to read?
@@ -510,7 +508,7 @@ Block::ID Filesystem::blockAt(const INode& inode, uint64_t offset) {
 
 Block::ID Filesystem::indirectBlockAt(Block::ID bid, uint64_t offset, uint64_t size) {
   Block block;
-  this->disk->get(bid, block);
+  this->block_manager->get(bid, block);
   Block::ID* refs = (Block::ID*) &block;
 
   uint64_t index = offset / size;
@@ -647,7 +645,7 @@ void Filesystem::deallocateLastBlock(INode& file_inode) {
     // 1. Load in first level block
     Block direct_ptrs_blk;
     Block::ID *direct_ptrs = (Block::ID *) &direct_ptrs_blk;
-    this->disk->get(file_inode.block_pointers[INode::DIRECT_POINTERS], direct_ptrs_blk);
+    this->block_manager->get(file_inode.block_pointers[INode::DIRECT_POINTERS], direct_ptrs_blk);
 
     // 2. Dellocate the direct block
     this->block_manager->release(direct_ptrs[logical_blk_num - INode::DIRECT_POINTERS - 1]);
@@ -664,14 +662,14 @@ void Filesystem::deallocateLastBlock(INode& file_inode) {
     // 1. Load in first level block
     Block single_indirect_ptrs_blk;
     Block::ID *single_indirect_ptrs = (Block::ID *) &single_indirect_ptrs_blk;
-    this->disk->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 1], single_indirect_ptrs_blk);
+    this->block_manager->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 1], single_indirect_ptrs_blk);
 
     Block::ID block_idx_in_level = logical_blk_num - INode::DIRECT_POINTERS - scale - 1;
 
     // 2. Load in second level block
     Block direct_ptrs_blk;
     Block::ID *direct_ptrs = (Block::ID *) &direct_ptrs_blk;
-    this->disk->get(single_indirect_ptrs[block_idx_in_level / scale], direct_ptrs_blk);
+    this->block_manager->get(single_indirect_ptrs[block_idx_in_level / scale], direct_ptrs_blk);
 
     // 3. Deallocate the direct block
     this->block_manager->release(direct_ptrs[block_idx_in_level % scale]);
@@ -692,21 +690,21 @@ void Filesystem::deallocateLastBlock(INode& file_inode) {
     // 1. Load in first level block
     Block double_indirect_ptrs_blk;
     Block::ID *double_indirect_ptrs = (Block::ID *) &double_indirect_ptrs_blk;
-    this->disk->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 2], double_indirect_ptrs_blk);
+    this->block_manager->get(file_inode.block_pointers[INode::DIRECT_POINTERS + 2], double_indirect_ptrs_blk);
 
     Block::ID block_idx_in_level = logical_blk_num - INode::DIRECT_POINTERS - scale - scale * scale - 1;
 
     // 2. Load in second level block
     Block single_indirect_ptrs_blk;
     Block::ID *single_indirect_ptrs = (Block::ID *) &single_indirect_ptrs_blk;
-    this->disk->get(double_indirect_ptrs[block_idx_in_level / (scale * scale)], single_indirect_ptrs_blk);
+    this->block_manager->get(double_indirect_ptrs[block_idx_in_level / (scale * scale)], single_indirect_ptrs_blk);
 
     Block::ID block_idx_in_level_two = block_idx_in_level % (scale * scale);
 
     // 3. Load in third level block
     Block direct_ptrs_blk;
     Block::ID *direct_ptrs = (Block::ID *) &direct_ptrs_blk;
-    this->disk->get(single_indirect_ptrs[block_idx_in_level_two / scale], direct_ptrs_blk);
+    this->block_manager->get(single_indirect_ptrs[block_idx_in_level_two / scale], direct_ptrs_blk);
 
     // 4. Deallocate direct block
     this->block_manager->release(direct_ptrs[block_idx_in_level_two % scale]);

--- a/src/lib/Filesystem.h
+++ b/src/lib/Filesystem.h
@@ -4,7 +4,6 @@
 #include "INode.h"
 #include "BlockManager.h"
 #include "INodeManager.h"
-#include "Storage.h"
 #include "Directory.h"
 
 struct statvfs;
@@ -12,12 +11,10 @@ struct statvfs;
 class Filesystem {
   BlockManager *block_manager;
   INodeManager *inode_manager;
-  Storage *disk;
 public:
-  Filesystem(BlockManager &block_manager, INodeManager& inode_manager, Storage &storage);
+  Filesystem(BlockManager &block_manager, INodeManager& inode_manager);
   ~Filesystem();
 
-  void mkfs(uint64_t nblocks);
   void mkfs(uint64_t nblocks, uint64_t niblocks);
   void statfs(struct statvfs* info);
 
@@ -34,6 +31,7 @@ public:
   INode     getINode(INode::ID id);
   INode     getINode(const std::string& path);
   INode::ID getINodeID(const std::string& path);
+  INode::ID newINodeID();
 
   void save(const Directory& directory);
   void save(INode::ID id, const INode& inode);

--- a/src/lib/Filesystem.h
+++ b/src/lib/Filesystem.h
@@ -17,7 +17,8 @@ public:
   Filesystem(BlockManager &block_manager, INodeManager& inode_manager, Storage &storage);
   ~Filesystem();
 
-  void mkfs();
+  void mkfs(uint64_t nblocks);
+  void mkfs(uint64_t nblocks, uint64_t niblocks);
   void statfs(struct statvfs* info);
 
   int  read(INode::ID file_inode_num, char *buffer, size_t size, size_t offset);

--- a/src/lib/Filesystem.h
+++ b/src/lib/Filesystem.h
@@ -12,11 +12,16 @@ class Filesystem {
   BlockManager* block_manager;
   INodeManager* inode_manager;
   uint64_t      max_file_size;
+  char*         mount_point;
+  bool          parallel;
+  bool          debug;
 public:
+  Filesystem(int argc, char** argv, bool mkfs);
   Filesystem(BlockManager &block_manager, INodeManager& inode_manager);
   ~Filesystem();
 
   void mkfs(uint64_t nblocks, uint64_t niblocks);
+  int  mount(fuse_operations* ops);
   void statfs(struct statvfs* info);
 
   int  read(INode::ID file_inode_num, char *buffer, size_t size, size_t offset);

--- a/src/mkfs.cpp
+++ b/src/mkfs.cpp
@@ -1,13 +1,11 @@
 #include <iostream>
 #include <vector>
 
-#include "lib/CommandLine.h"
 #include "lib/Filesystem.h"
 
 int main(int argc, char** argv) {
-  Filesystem* fs = parse(argc, argv, true);
+  Filesystem fs(argc, argv, true);
   // TODO: Check that everything was saved?
-  delete fs;
 
   /*
   ******************************************************************

--- a/src/mkfs.cpp
+++ b/src/mkfs.cpp
@@ -1,55 +1,13 @@
 #include <iostream>
 #include <vector>
+
+#include "lib/CommandLine.h"
 #include "lib/Filesystem.h"
-#include "lib/blocks/StackBasedBlockManager.h"
-#include "lib/inodes/LinearINodeManager.h"
-#include "lib/storage/MemoryStorage.h"
 
 int main(int argc, char** argv) {
-
-  // Read number of blocks on disk
-  if (argc < 2) {
-    std::cout << "Not Enough Arguments." << std::endl;
-  }
-
-  uint64_t nblocks = atoi(argv[1]);
-  Storage *disk = new MemoryStorage(nblocks);
-
-  // Create a block for superblock
-  Block block;
-  Superblock* superblock = (Superblock*) &block;
-  memset(&block, 0, Block::SIZE);
-
-  // Set basic superblock parameters
-  superblock->magic = 3199905246;
-  superblock->block_size = Block::SIZE;
-  superblock->block_count = nblocks;
-
-  // Have approximately 1 inode per 2048 bytes of disk space
-  superblock->inode_block_start = 1;
-  if (((nblocks * Block::SIZE) / 2048 * INode::SIZE) % Block::SIZE == 0) {
-    superblock->inode_block_count = ((nblocks * Block::SIZE) / 2048 * INode::SIZE) / Block::SIZE;
-  } else {
-    superblock->inode_block_count = ((nblocks * Block::SIZE) / 2048 * INode::SIZE) / Block::SIZE + 1;
-  }
-  superblock->data_block_start = superblock->inode_block_start + superblock->inode_block_count;
-  superblock->data_block_count = superblock->block_count - superblock->data_block_start;
-
-  // Write superblock to disk
-  disk->set(0, block);
-
-  // Initialize managers and call mkfs
-  LinearINodeManager inode_manager(*disk);
-  StackBasedBlockManager block_manager(*disk);
-  Filesystem filesystem(block_manager, inode_manager, *disk);
-  filesystem.mkfs();
-
-  // Debug stuff
-  disk->get(0, block);
-  std::cout << "INode block count: " << superblock->inode_block_count << std::endl;
-  std::cout << "Real data block count: " << superblock->data_block_count << std::endl;
-  std::cout << "Size of Inode: " << sizeof(INode) << std::endl;
-  // std::cout << "Should be wasting 1-2 data blocks" << std::endl;
+  Filesystem* fs = parse(argc, argv, true);
+  // TODO: Check that everything was saved?
+  delete fs;
 
   /*
   ******************************************************************


### PR DESCRIPTION
This supersedes the old CLI PR.  The interface is as follows (except for a hack where the block count option is currently required):

```
USAGE: program [options] [mount-point]
  --block-size  -b <num>  Block size (defaults to 4096).
  --block-count -n <num>  Total number of blocks (mkfs only).
  --inode-count -i <num>  Minimum number of INodes (mkfs only).
  --disk-file   -f <str>  File or device to use for storage.
  --debug       -d        Enable FUSE debugging output.
  --parallel    -p        Run in multithreaded mode.
```

When running `bin/fuse` the process will always remain in the foreground.